### PR TITLE
`maxLength` parameter for #text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # node-tika #
 
-Provides text extraction, metadata extraction, mime-type detection, text-encoding detection and language 
+Provides text extraction, metadata extraction, mime-type detection, text-encoding detection and language
 detection. All via a native Java bridge with the Apache Tika content-analysis toolkit. Bundles [Tika 1.8](http://tika.apache.org/1.8/index.html).
 
 [![Build Status](https://travis-ci.org/ICIJ/node-tika.png?branch=master)](https://travis-ci.org/ICIJ/node-tika) [![npm version](https://badge.fury.io/js/tika.png)](https://badge.fury.io/js/tika)
 
 Depends on [node-java](https://github.com/joeferner/node-java), which itself requires the JDK and Python 2 (not 3) to compile.
 
-Requires JDK 7. Run `node version` to check the version that `node-java` is using. If the wrong version is 
+Requires JDK 7. Run `node version` to check the version that `node-java` is using. If the wrong version is
 reported even if you installed JDK 1.7, make sure `JAVA_HOME` is set to the correct path then delete `node_modules/java` and rerun `npm install`.
 
 ## Extracting text ##
@@ -53,6 +53,7 @@ The available options are the following.
  - `contentType` to provide a hint to Tika on which parser to use.
  - `outputEncoding` to specify the text output encoding. Defaults to UTF-8.
  - `password` to set a password to be used for encrypted files.
+ - `maxLength` to specify a max number of character to extract.
 
 ### OCR options ###
 

--- a/src/main/java/cg/m/nodetika/RichTextContentHandler.java
+++ b/src/main/java/cg/m/nodetika/RichTextContentHandler.java
@@ -24,6 +24,10 @@ import org.xml.sax.SAXException;
 import java.io.Writer;
 
 class RichTextContentHandler extends WriteOutContentHandler {
+	public RichTextContentHandler(Writer writer, int maxLength) {
+		super(writer, maxLength);
+	}
+
 	public RichTextContentHandler(Writer writer) {
 		super(writer);
 	}

--- a/test/data/big/file.txt
+++ b/test/data/big/file.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, delectus intellegat consectetuer eam in, at omnium sapientem comprehensam vel. Eos impedit adipisci at. Eam nulla omittam constituam ne, an quem deserunt vis. Te sit facete possim similique, usu rebum munere dictas ne.

--- a/test/tika.js
+++ b/test/tika.js
@@ -199,6 +199,26 @@ suite('document tests', function() {
 	});
 });
 
+suite('partial document extraction tests', function() {
+	test('extract from long txt', function(done) {
+		tika.text('test/data/big/file.txt', { maxLength: 10 }, function(err, text) {
+			assert.ifError(err);
+			assert.equal(text.length, 10);
+			assert.equal(text, 'Lorem ipsu');
+			done();
+		});
+	});
+
+	test('extract from pdf', function(done) {
+		tika.text('test/data/file.pdf', { maxLength: 10 }, function(err, text) {
+			assert.ifError(err);
+			assert.equal(text.length, 10);
+			assert.equal(text.trim(), 'Just some');
+			done();
+		});
+	});
+});
+
 suite('obscure document tests', function() {
 	test('extract from Word 2003 XML', function(done) {
 		tika.text('test/data/obscure/word2003.xml', function(err, text) {


### PR DESCRIPTION
Hi!
I added the `maxLength` option to text extraction.
Now you can pass it as option to `tika.text(...)` in this way:

```javascript
options = { maxLength: 15 }
tika.text('test/data/file.pdf', options, function(err, text) {
    console.log(text); // "First 15 charac"...
});
```

I needed it for my project, just sharing :)
