### PR TITLE
Dependency upgrades and npm test script

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,4 +9,4 @@
 # Please keep the list sorted.
 
 Matthias Götzke <m.goetzke@curasystems.de>	Explicit UTF-8 output encoding.
-James Garner <james@beamery.com>  Dependency upgrades and npm test script.
+James Garner <james@beamery.com>	Dependency upgrades and npm test script.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,3 +9,4 @@
 # Please keep the list sorted.
 
 Matthias Götzke <m.goetzke@curasystems.de>	Explicit UTF-8 output encoding.
+James Garner <james@beamery.com>  Dependency upgrades and npm test script.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
 	"name": "tika",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"description": "Apache Tika bridge. Text extraction, metadata extraction, mimetype detection and language detection.",
+	"scripts": {
+		"test": "mocha --ui tdd test"
+	},
 	"keywords": [
 		"docx",
 		"pdf",
@@ -17,6 +20,10 @@
 		{
 			"name": "Matthias Götzke",
 			"email": "m.goetzke@curasystems.de"
+		},
+		{
+			"name": "James Garner",
+			"email": "james@beamery.com"
 		}
 	],
 	"repository": {
@@ -28,11 +35,11 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"java": "~0.7.0"
+		"java": "~0.8.0"
 	},
 	"devDependencies": {
-		"mocha": "~2.5.3",
-		"istanbul": "~0.4.3"
+		"mocha": "~3.2.0",
+		"istanbul": "~0.4.5"
 	},
 	"engines" : {
 		"node" : ">=0.10.0"


### PR DESCRIPTION
The `java` dependency at version `0.7.2` under node.js version `7.5` does not work; `0.8` is required. I ran `npm-check-updates` to upgrade all dependencies in `package.json`. To verify this worked, I tried to run the tests (which are very good), but node-ism `npm test` didn't work, so I added a `test` script to run `mocha` as well. All tests are passing and `tika` is working on the latest node.js version. 🎉 

At [Beamery](https://beamery.com) we are using `tika` to extract text from URLs and appreciate ICIJ's hard work.