### PR TITLE
Upgrade to Tika v1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DELETE_ON_ERROR:
 
-TIKA_VERSION := 1.18
+TIKA_VERSION := 1.20
 JAVAS := $(shell ls src/main/java/org/icij/nodetika/*.java)
 JAR := jar/node-tika-$(TIKA_VERSION).jar
 PARSERS_JAR := build/tika/tika-core/target/tika-parsers-$(TIKA_VERSION).jar
@@ -18,7 +18,7 @@ $(PARSERS_JAR): build/tika-$(TIKA_VERSION)
 
 build/tika-$(TIKA_VERSION)-src.zip: build
 	if [ ! -f $@ ]; then \
-		curl http://www.eu.apache.org/dist/tika/tika-$(TIKA_VERSION)-src.zip --output build/tika-$(TIKA_VERSION)-src.zip; \
+		curl http://www.apache.org/dist/tika/tika-$(TIKA_VERSION)-src.zip --output build/tika-$(TIKA_VERSION)-src.zip; \
 	else \
 		touch $@; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DELETE_ON_ERROR:
 
-TIKA_VERSION := 1.17
+TIKA_VERSION := 1.18
 JAVAS := $(shell ls src/main/java/org/icij/nodetika/*.java)
 JAR := jar/node-tika-$(TIKA_VERSION).jar
 PARSERS_JAR := build/tika/tika-core/target/tika-parsers-$(TIKA_VERSION).jar

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DELETE_ON_ERROR:
 
-TIKA_VERSION := 1.13
+TIKA_VERSION := 1.17
 JAVAS := $(shell ls src/main/java/org/icij/nodetika/*.java)
 JAR := jar/node-tika-$(TIKA_VERSION).jar
 PARSERS_JAR := build/tika/tika-core/target/tika-parsers-$(TIKA_VERSION).jar

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"java": "^0.9.0"
+		"java": "^0.10.0"
 	},
 	"devDependencies": {
 		"mocha": "~3.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"java": "^0.10.0"
+		"java": "^0.11.0"
 	},
 	"devDependencies": {
 		"mocha": "~3.2.0",

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"java": "~0.8.0"
+		"java": "^0.9.0"
 	},
 	"devDependencies": {
 		"mocha": "~3.2.0",
 		"istanbul": "~0.4.5"
 	},
-	"engines" : {
-		"node" : ">=0.10.0"
+	"engines": {
+		"node": ">=0.10.0"
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.apache.tika</groupId>
 		<artifactId>tika-parent</artifactId>
-		<version>1.17</version>
+		<version>1.18</version>
 		<relativePath>../tika-parent/pom.xml</relativePath>
 	</parent>
 
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.6.2</version>
+			<version>2.8.1</version>
 			<scope>compile</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.apache.tika</groupId>
 		<artifactId>tika-parent</artifactId>
-		<version>1.18</version>
+		<version>1.20</version>
 		<relativePath>../tika-parent/pom.xml</relativePath>
 	</parent>
 
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.1</version>
+			<version>2.8.5</version>
 			<scope>compile</scope>
 		</dependency>
 
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>com.github.jai-imageio</groupId>
 			<artifactId>jai-imageio-core</artifactId>
-			<version>1.3.1</version>
+			<version>1.4.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.apache.tika</groupId>
 		<artifactId>tika-parent</artifactId>
-		<version>1.13</version>
+		<version>1.17</version>
 		<relativePath>../tika-parent/pom.xml</relativePath>
 	</parent>
 
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.4</version>
+				<version>2.6</version>
 				<configuration>
 					<outputDirectory>jar</outputDirectory>
 				</configuration>

--- a/src/main/java/org/icij/nodetika/NodeTika.java
+++ b/src/main/java/org/icij/nodetika/NodeTika.java
@@ -68,6 +68,7 @@ public class NodeTika {
 
 		if (uri.startsWith("http://") || uri.startsWith("https://") || uri.startsWith("ftp://")) {
 			final URLConnection urlConnection = new URL(uri).openConnection();
+			urlConnection.setRequestProperty("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) Gecko/20100101 Firefox/58.0");
 
 			// If a metadata object was passed, fill it with the content-type returned from the server.
 			if (metadata != null) {

--- a/test/tika.js
+++ b/test/tika.js
@@ -454,9 +454,9 @@ suite('error handling tests', function() {
 
 suite('http extraction tests', function() {
 	test('extract from pdf over http', function(done) {
-		tika.text('http://www.ohchr.org/EN/UDHR/Documents/UDHR_Translations/eng.pdf', function(err, text) {
+		tika.text('https://tools.ietf.org/pdf/rfc2324.pdf', function(err, text) {
 			assert.ifError(err);
-			assert.ok(-1 !== text.indexOf('Universal Declaration of Human Rights'));
+			assert.ok(-1 !== text.indexOf('Hyper Text Coffee Pot Control Protocol'));
 			done();
 		});
 	});

--- a/test/tika.js
+++ b/test/tika.js
@@ -438,7 +438,7 @@ suite('error handling tests', function() {
 	test('extract from encrypted doc', function(done) {
 		tika.text('test/data/encrypted/file.doc', function(err, text) {
 			assert.ok(err);
-			assert.ok(-1 !== err.toString().indexOf('EncryptedDocumentException: Cannot process encrypted word file'));
+			assert.ok(-1 !== err.toString().indexOf('EncryptedDocumentException: Unable to process: document is encrypted'));
 			done();
 		});
 	});
@@ -464,9 +464,10 @@ suite('http extraction tests', function() {
 
 suite('ftp extraction tests', function() {
 	test('extract from text file over ftp', function(done) {
-		tika.text('ftp://ftp.ed.ac.uk/INSTRUCTIONS-FOR-USING-THIS-SERVICE', function(err, text) {
+		this.timeout(5000);
+		tika.text('ftp://ftp.ietf.org/rfc/rfc959.txt', function(err, text) {
 			assert.ifError(err);
-			assert.ok(-1 !== text.indexOf('This service is managed by Information Services'));
+			assert.ok(-1 !== text.indexOf('FILE TRANSFER PROTOCOL'));
 			done();
 		});
 	});

--- a/tika.js
+++ b/tika.js
@@ -11,7 +11,7 @@
 
 var java = require('java');
 
-java.classpath.push(__dirname + '/jar/node-tika-1.17.jar');
+java.classpath.push(__dirname + '/jar/node-tika-1.18.jar');
 java.options.push('-Djava.awt.headless=true');
 java.options.push('-Xrs');
 

--- a/tika.js
+++ b/tika.js
@@ -11,7 +11,7 @@
 
 var java = require('java');
 
-java.classpath.push(__dirname + '/jar/node-tika-1.13.jar');
+java.classpath.push(__dirname + '/jar/node-tika-1.17.jar');
 java.options.push('-Djava.awt.headless=true');
 java.options.push('-Xrs');
 

--- a/tika.js
+++ b/tika.js
@@ -11,7 +11,7 @@
 
 var java = require('java');
 
-java.classpath.push(__dirname + '/jar/node-tika-1.18.jar');
+java.classpath.push(__dirname + '/jar/node-tika-1.20.jar');
 java.options.push('-Djava.awt.headless=true');
 java.options.push('-Xrs');
 


### PR DESCRIPTION
- Updated `tika` to v1.17.
- Updated `node-java` to v0.9.0.
- Increased timeout for FTP test and updated link to test file.
- Updated encrypted docx test to reflect new output from Tika.

All tests are passing.