### PR TITLE
Upgrade node-java depenendency to 0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"java": "~0.8.0"
+		"java": "~0.11.0"
 	},
 	"devDependencies": {
 		"mocha": "~3.2.0",
 		"istanbul": "~0.4.5"
 	},
-	"engines" : {
-		"node" : ">=0.10.0"
+	"engines": {
+		"node": ">=0.10.0"
 	}
 }


### PR DESCRIPTION
The current version of node-java doesn't compile on the lastest LTS release of Node. Upgrading to 0.11.0 makes node-tika work on Node 8.12.0 as well as 10.13.0.